### PR TITLE
Changing SESSION_SERIALIZER to PickleSerializer, quickfix for new Django...

### DIFF
--- a/source/going_social.rst
+++ b/source/going_social.rst
@@ -64,6 +64,12 @@ logowaniu (też w pliku ``settings.py``::
     LOGIN_REDIRECT_URL = '/polls/'  # tutaj ma trafić użytkownik zaraz po zalogowaniu
     LOGIN_ERROR_URL    = '/login/'
 
+W pliku ``settings.py`` odszukajmy jeszcze wpis ``SESSION_SERIALIZER`` i ustawmy go na nową wartość::
+
+    SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
+    
+Jest to związane z ostatnimi zmianami w nowej wersji Django, do których nasz pakiet django-carrots nie zdążył się przystosować ;)
+
 Docelowo chcemy, aby nasza aplikacja potrafiła publikować wyniki ankiet.
 W tym celu potrzebne jest dodatkowe uprawnienie. Do pliku ``settings.py`` dopisujemy::
 


### PR DESCRIPTION
... version

django-carrots uses an old version of django-social-auth which doesn't support changes in Django since 1.5.3 (1.6).
Read more: https://github.com/omab/python-social-auth/issues/36
