### PR TITLE
Fix alignment in quickstart.

### DIFF
--- a/source/django_models.rst
+++ b/source/django_models.rst
@@ -11,7 +11,7 @@ Notre application inclura des questions et leurs réponses, nous allons donc
 créer deux modèles : ``Poll`` et ``Choice``. Le modèle ``Poll`` contient le
 contenu des questions ainsi que la date de publication. Le modèle ``Choice``
 contient une référence vers la question adéquate, le contenu des réponses et le
- nombre de votes.
+nombre de votes.
 
 Dans le fichier ``polls/models.py`` nous écrivons::
 

--- a/source/python_quickstart.rst
+++ b/source/python_quickstart.rst
@@ -937,46 +937,46 @@ l'affichage sur un nombre de caractères donné :
 
 .. testcode::
 
-    WIDTH = 28
+    WIDTH = 26
 
     print("-" * WIDTH)
-    print("| Name and last name |  poids  |")
+    print("| Prénom et nom |  Poids |")
     print("-" * WIDTH)
-    print("| %15s | %6.2f |" % ("Lucas", 67.5))
-    print("| %15s | %6.2f |" % ("Camille", 123))
+    print("| %13s | %6.2f |" % ("Lucas", 67.5))
+    print("| %13s | %6.2f |" % ("Camille", 123))
     print("-" * WIDTH)
 
 .. testoutput::
 
-    --------------------------------
-    | Name and last name  |  poids|
-    --------------------------------
-    |               Lucas |  67.50 |
-    |             Camille | 123.00 |
-    --------------------------------
+    --------------------------
+    | Prénom et nom |  Poids |
+    --------------------------
+    |         Lucas |  67.50 |
+    |       Camille | 123.00 |
+    --------------------------
 
 Nous pouvons aussi aligner les chaînes de caractères à gauche en
 prefixant le nombre de caractères par un ``-`` :
 
 .. testcode::
 
-    WIDTH = 28
+    WIDTH = 26
 
     print("-" * WIDTH)
-    print("| Name and last name |  poids |")
+    print("| Prénom et nom |  Poids |")
     print("-" * WIDTH)
-    print("| %-15s | %6.2f |" % ("Lucas", 67.5))
-    print("| %-15s | %6.2f |" % ("Camille", 123))
+    print("| %-13s | %6.2f |" % ("Lucas", 67.5))
+    print("| %-13s | %6.2f |" % ("Camille", 123))
     print("-" * WIDTH)
 
 .. testoutput::
 
-    -------------------------------
-    | Name and last name|  poids |
-    -------------------------------
-    | Lucas             |  67.50  |
-    | Camille           | 123.00  |
-    -------------------------------
+    --------------------------
+    | Prénom et nom |  Poids |
+    --------------------------
+    | Lucas         |  67.50 |
+    | Camille       | 123.00 |
+    --------------------------
 
 Je vous laisse chercher comment faire pour aligner au centre :).
 


### PR DESCRIPTION
The text was overflowing: the actual width is 31, yet we used 28...